### PR TITLE
feat: add `.on_retry(fn)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ async fn main() {
         .max_delay(Duration::from_secs(3)) // Cap maximum delay at 3 seconds
         .exponential(Duration::from_secs(1)) // Use exponential backoff
         .full_jitter()                     // Add randomized jitter
+        .on_retry(|| {                     // Run before each retry
+            println!("retrying...")
+        })
         .retry(|| async {
             fallible_operation("connection failed").await
         })

--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ async fn main() {
         .max_delay(Duration::from_secs(3)) // Cap maximum delay at 3 seconds
         .exponential(Duration::from_secs(1)) // Use exponential backoff
         .full_jitter()                     // Add randomized jitter
-        .on_retry(|| {                     // Run before each retry
-            println!("retrying...")
+        .on_retry(|prev, attempts| {       // Run before each retry.
+            println!("In the {}-th attempt, the returned result is {:?}.", attempts, prev);
+            println!("Start next attempt");
         })
         .retry(|| async {
             fallible_operation("connection failed").await

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -25,6 +25,18 @@ async fn main() {
             .await
     });
 
+    let retry = tokio::spawn(async move {
+        mulligan::until_ok()
+            .stop_after(10)
+            .full_jitter()
+            .fixed(Duration::from_millis(200))
+            .on_retry(|| { unreachable!("this on_retry() should not be called!") })
+            .on_retry(|| { println!("[retry] start to call retry()") })
+            .retry(|| async { this_errors("[retry] running").await })
+            .await
+    });
+
     let _ = hello.await;
     let _ = world.await;
+    let _ = retry.await;
 }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -30,8 +30,8 @@ async fn main() {
             .stop_after(10)
             .full_jitter()
             .fixed(Duration::from_millis(200))
-            .on_retry(|| { unreachable!("this on_retry() should not be called!") })
-            .on_retry(|| { println!("[retry] start to call retry()") })
+            .on_retry(|_, _| { unreachable!("this on_retry() should not be called!") })
+            .on_retry(|res, attempt| { println!("[retry] start to call retry(): attempt = {}, prev = {:?}", attempt, res) })
             .retry(|| async { this_errors("[retry] running").await })
             .await
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ where
         strategy: Strategy::Fixed(Duration::from_secs(0)),
         jitter: Jitter::None,
         max: None,
+        on_retry: None,
         _phantom: PhantomData,
     }
 }
@@ -77,6 +78,7 @@ where
     strategy: Strategy,
     jitter: Jitter,
     max: Option<Duration>,
+    on_retry: Option<Box<dyn Fn() + Send + Sync + 'static>>,
     _phantom: PhantomData<(T, E)>,
 }
 
@@ -112,6 +114,12 @@ where
         let mut previous = Duration::from_secs(0);
         let mut attempt: u32 = 0;
         loop {
+            if attempt > 0 {
+                if let Some(on_retry) = &self.on_retry {
+                    on_retry()
+                }
+            }
+
             let res = f().await;
             if self.stop_after.map_or(false, |max| attempt >= max) | (self.until)(&res) {
                 return res;
@@ -125,6 +133,14 @@ where
             previous = delay;
             attempt += 1;
         }
+    }
+    /// Sets the function to be called before each retry; it will not be called before the first execution.
+    pub fn on_retry<F>(&mut self, on_retry: F) -> &mut Self
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        self.on_retry = Some(Box::new(on_retry));
+        self
     }
     /// Sets the maximum number of attempts to retry before stopping regardless of whether `until` condition has been met.
     pub fn stop_after(&mut self, attempts: u32) -> &mut Self {


### PR DESCRIPTION
This pull request resolves https://github.com/theelderbeever/mulligan/issues/6.

Example: 

```rust
mulligan::until_ok()
    .on_retry(|| { log::error!("A new retry!!!") })
    .retry(|| async {})
    .await
```

The given closure will be executed once before each retry (except for the first execution). The closure is not asynchronous; it is simply for convenience in handling error logs and other simple cases.

The modification still ensures that `Mulligan` is `Send + Sync`.