### PR TITLE
19-remove-static-lifetimes-on-before-and-after-functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "mulligan"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-std",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mulligan"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "A flexible retry library for Rust async operations with configurable backoff strategies and jitter."
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,6 @@ rand = { version = "0.8" }
 name = "hello_world"
 required-features = ["tokio"]
 
-
-
 [[example]]
 name = "reqwest"
 required-features = ["tokio"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,8 @@ pub use jitter::{Decorrelated, Equal, Full, Jitter, NoJitter};
 ///     .await;
 /// # }
 /// ```
-pub fn until_ok<T, E>() -> Mulligan<T, E, impl Fn(&Result<T, E>) -> bool, NoJitter, Fixed> {
+pub fn until_ok<T, E>() -> Mulligan<'static, T, E, impl Fn(&Result<T, E>) -> bool, NoJitter, Fixed>
+{
     until::<T, E, _>(|result: &Result<T, E>| result.is_ok())
 }
 
@@ -59,7 +60,7 @@ pub fn until_ok<T, E>() -> Mulligan<T, E, impl Fn(&Result<T, E>) -> bool, NoJitt
 ///     .await;
 /// # }
 /// ```
-pub fn until<T, E, Cond>(f: Cond) -> Mulligan<T, E, Cond, NoJitter, Fixed>
+pub fn until<T, E, Cond>(f: Cond) -> Mulligan<'static, T, E, Cond, NoJitter, Fixed>
 where
     Cond: Fn(&Result<T, E>) -> bool,
 {
@@ -76,7 +77,7 @@ where
 }
 
 /// Not meant to be constructed directly. Use `mulligan::until_ok()` or `mulligan::until(...)` to construct.
-pub struct Mulligan<T, E, Cond, Jit, Back>
+pub struct Mulligan<'a, T, E, Cond, Jit, Back>
 where
     Cond: Fn(&Result<T, E>) -> bool,
     Jit: jitter::Jitter,
@@ -87,12 +88,12 @@ where
     backoff: Back,
     jitterable: Jit,
     max: Option<Duration>,
-    before_attempt: Option<Box<dyn Fn(u32) + Send + Sync>>,
-    after_attempt: Option<Box<dyn Fn(&Result<T, E>, u32) + Send + Sync>>,
+    before_attempt: Option<Box<dyn Fn(u32) + Send + Sync + 'a>>,
+    after_attempt: Option<Box<dyn Fn(&Result<T, E>, u32) + Send + Sync + 'a>>,
     _phantom: PhantomData<(T, E)>,
 }
 
-impl<T, E, Cond, Jit, Back> Mulligan<T, E, Cond, Jit, Back>
+impl<'a, T, E, Cond, Jit, Back> Mulligan<'a, T, E, Cond, Jit, Back>
 where
     Cond: Fn(&Result<T, E>) -> bool,
     Jit: jitter::Jitter,
@@ -199,7 +200,7 @@ where
     /// represents the number of times it has been executed.
     pub fn before_attempt<F>(mut self, before_attempt: F) -> Self
     where
-        F: Fn(u32) + Send + Sync + 'static,
+        F: Fn(u32) + Send + Sync + 'a,
     {
         self.before_attempt = Some(Box::new(before_attempt));
         self
@@ -212,7 +213,7 @@ where
     /// represents the number of times it has been executed.
     pub fn after_attempt<F>(mut self, after_attempt: F) -> Self
     where
-        F: Fn(&Result<T, E>, u32) + Send + Sync + 'static,
+        F: Fn(&Result<T, E>, u32) + Send + Sync + 'a,
     {
         self.after_attempt = Some(Box::new(after_attempt));
         self
@@ -227,7 +228,7 @@ where
         self.jitterable.jitter(delay, self.max)
     }
     /// Adjust the backoff by the provided jitter strategy
-    pub fn jitter<J>(self, jitter: J) -> Mulligan<T, E, Cond, J, Back>
+    pub fn jitter<J>(self, jitter: J) -> Mulligan<'a, T, E, Cond, J, Back>
     where
         J: jitter::Jitter,
     {
@@ -243,7 +244,7 @@ where
         }
     }
     /// Adjust the calculated backoff by choosing a random delay between 0 and the backoff value
-    pub fn full_jitter(self) -> Mulligan<T, E, Cond, jitter::Full, Back> {
+    pub fn full_jitter(self) -> Mulligan<'a, T, E, Cond, jitter::Full, Back> {
         Mulligan {
             stop_after: self.stop_after,
             until: self.until,
@@ -256,7 +257,7 @@ where
         }
     }
     /// Adjust the calculated backoff by choosing a random delay between backoff / 2 and the backoff value
-    pub fn equal_jitter(self) -> Mulligan<T, E, Cond, jitter::Equal, Back> {
+    pub fn equal_jitter(self) -> Mulligan<'a, T, E, Cond, jitter::Equal, Back> {
         Mulligan {
             stop_after: self.stop_after,
             until: self.until,
@@ -272,7 +273,7 @@ where
     pub fn decorrelated_jitter(
         self,
         base: Duration,
-    ) -> Mulligan<T, E, Cond, jitter::Decorrelated, Back> {
+    ) -> Mulligan<'a, T, E, Cond, jitter::Decorrelated, Back> {
         Mulligan {
             stop_after: self.stop_after,
             until: self.until,
@@ -285,7 +286,7 @@ where
         }
     }
     /// Delay by the calculated backoff strategy.
-    pub fn backoff<B>(self, backoff: B) -> Mulligan<T, E, Cond, Jit, B>
+    pub fn backoff<B>(self, backoff: B) -> Mulligan<'a, T, E, Cond, Jit, B>
     where
         B: Backoff,
     {
@@ -301,7 +302,7 @@ where
         }
     }
     /// Wait a fixed amount of time between each retry.
-    pub fn fixed(self, dur: Duration) -> Mulligan<T, E, Cond, Jit, Fixed> {
+    pub fn fixed(self, dur: Duration) -> Mulligan<'a, T, E, Cond, Jit, Fixed> {
         Mulligan {
             stop_after: self.stop_after,
             until: self.until,
@@ -314,7 +315,7 @@ where
         }
     }
     /// Wait a growing amount of time between each retry `base * attempt`
-    pub fn linear(self, dur: Duration) -> Mulligan<T, E, Cond, Jit, Linear> {
+    pub fn linear(self, dur: Duration) -> Mulligan<'a, T, E, Cond, Jit, Linear> {
         Mulligan {
             stop_after: self.stop_after,
             until: self.until,
@@ -327,7 +328,7 @@ where
         }
     }
     /// Wait a growing amount of time between each retry `base * 2.pow(attempt)`
-    pub fn exponential(self, dur: Duration) -> Mulligan<T, E, Cond, Jit, Exponential> {
+    pub fn exponential(self, dur: Duration) -> Mulligan<'a, T, E, Cond, Jit, Exponential> {
         Mulligan {
             stop_after: self.stop_after,
             until: self.until,


### PR DESCRIPTION
# Lifetime Changes in Mulligan

## Overview

The `before_attempt` and `after_attempt` callbacks no longer require `'static` lifetime bounds. This allows closures that capture references to stack variables, making the API more flexible and ergonomic.

## What Changed

### Before

```rust
pub struct Mulligan<T, E, Cond, Jit, Back> {
    // ...
    before_attempt: Option<Box<dyn Fn(u32) + Send + Sync>>,  // implicitly 'static
    after_attempt: Option<Box<dyn Fn(&Result<T, E>, u32) + Send + Sync>>,  // implicitly 'static
}
```

### After

```rust
pub struct Mulligan<'a, T, E, Cond, Jit, Back> {
    // ...
    before_attempt: Option<Box<dyn Fn(u32) + Send + Sync + 'a>>,
    after_attempt: Option<Box<dyn Fn(&Result<T, E>, u32) + Send + Sync + 'a>>,
}
```

## Benefits

1. **Capture Stack References**: Closures can now capture references to variables on the stack
2. **Better Ergonomics**: No need to use `Arc`, `move`, or other workarounds for simple logging
3. **More Flexible**: Lifetime is inferred automatically in most cases

## Examples

### Capturing Stack Variables

```rust
let operation_name = "database query";

mulligan::until_ok()
    .stop_after(5)
    .before_attempt(|attempt| {
        // Captures reference to operation_name without requiring 'static
        println!("Retrying {}: attempt {}", operation_name, attempt);
    })
    .execute_sync(|| perform_operation())
```

### Before (Required 'static)

```rust
// Had to clone or use Arc to satisfy 'static requirement
let operation_name = "database query".to_string();

mulligan::until_ok()
    .before_attempt(move |attempt| {
        // Had to move/clone the string
        println!("Retrying {}: attempt {}", operation_name, attempt);
    })
    .execute_sync(|| perform_operation())
```

### After (Can use references)

```rust
// Can directly capture references now
let operation_name = "database query";  // &str on the stack

mulligan::until_ok()
    .before_attempt(|attempt| {
        // Captures a reference - no clone needed!
        println!("Retrying {}: attempt {}", operation_name, attempt);
    })
    .execute_sync(|| perform_operation())
```

## Migration Guide

### For Most Users

No changes required! The lifetime parameter is inferred automatically. Your existing code will continue to work without modifications.

### For Users with Explicit Type Annotations

If you explicitly annotate `Mulligan` types, you'll need to add the lifetime parameter:

```rust
// Before
let retry: Mulligan<(), Error, _, NoJitter, Fixed> = mulligan::until_ok();

// After
let retry: Mulligan<'static, (), Error, _, NoJitter, Fixed> = mulligan::until_ok();
```

## Technical Details

- The `'a` lifetime parameter allows the `Mulligan` struct to hold closures that don't outlive `'a`
- When no references are captured, the lifetime is effectively `'static` and behaves as before
- When references are captured, the lifetime is tied to those references
- The lifetime is contravariant, meaning `Mulligan<'static, ...>` can be used where `Mulligan<'a, ...>` is expected

## Compatibility

- This is a **breaking change** for code that explicitly names the `Mulligan` type
- For most users who use type inference, this change is **fully backward compatible**
- The minimum supported Rust version remains unchanged
